### PR TITLE
Sequential items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_install:
   - cd zookeeper-3.4.6
   - bin/zkServer.sh start conf/zoo_sample.cfg
   - cd ..
-  - wget http://ftp.ps.pl/pub/apache//cassandra/2.2.1/apache-cassandra-2.2.1-bin.tar.gz
-  - tar -xzf apache-cassandra-2.2.1-bin.tar.gz
-  - cd apache-cassandra-2.2.1
+  - wget http://ftp.ps.pl/pub/apache/cassandra/2.2.4/apache-cassandra-2.2.4-bin.tar.gz
+  - tar -xzf apache-cassandra-2.2.4-bin.tar.gz
+  - cd apache-cassandra-2.2.4
   - bin/cassandra
   - cd ..
 after_failure:

--- a/HEADER
+++ b/HEADER
@@ -1,4 +1,4 @@
-Copyright (C) ${year} ${name} <${email}>
+Copyright (C) ${yearFrom}-${yearTo} ${name} <${email}>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,8 @@ allprojects {
         license {
             header rootProject.file('HEADER')
 
-            ext.year = Calendar.getInstance().get(Calendar.YEAR)
+            ext.yearFrom = 2015
+            ext.yearTo = Calendar.getInstance().get(Calendar.YEAR)
             ext.name = 'Łukasz Budnik'
             ext.email = 'lukasz.budnik@gmail.com'
         }

--- a/dqueue-jaxrs/src/main/java/com/github/lukaszbudnik/dqueue/jaxrs/core/QueueApplication.java
+++ b/dqueue-jaxrs/src/main/java/com/github/lukaszbudnik/dqueue/jaxrs/core/QueueApplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue-jaxrs/src/main/java/com/github/lukaszbudnik/dqueue/jaxrs/core/QueueConfiguration.java
+++ b/dqueue-jaxrs/src/main/java/com/github/lukaszbudnik/dqueue/jaxrs/core/QueueConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue-jaxrs/src/main/java/com/github/lukaszbudnik/dqueue/jaxrs/service/QueueService.java
+++ b/dqueue-jaxrs/src/main/java/com/github/lukaszbudnik/dqueue/jaxrs/service/QueueService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue-jaxrs/src/main/resources/cloudtag.properties
+++ b/dqueue-jaxrs/src/main/resources/cloudtag.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+# Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 #

--- a/dqueue-jaxrs/src/main/resources/dqueue.properties
+++ b/dqueue-jaxrs/src/main/resources/dqueue.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+# Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 #

--- a/dqueue-jaxrs/src/main/resources/html/form.html
+++ b/dqueue-jaxrs/src/main/resources/html/form.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+    Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/dqueue-jaxrs/src/main/resources/js/dqueue-1.0.0.js
+++ b/dqueue-jaxrs/src/main/resources/js/dqueue-1.0.0.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue-jaxrs/src/test/java/com/github/lukaszbudnik/dqueue/jaxrs/service/QueueServiceTest.java
+++ b/dqueue-jaxrs/src/test/java/com/github/lukaszbudnik/dqueue/jaxrs/service/QueueServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue-jaxrs/src/test/java/com/github/lukaszbudnik/dqueue/jaxrs/service/QueueServiceTest.java
+++ b/dqueue-jaxrs/src/test/java/com/github/lukaszbudnik/dqueue/jaxrs/service/QueueServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/FunctionalInterfaces.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/FunctionalInterfaces.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/FunctionalInterfaces.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/FunctionalInterfaces.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/Item.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/Item.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/Item.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/Item.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClient.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClient.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClient.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClient.java
@@ -9,6 +9,8 @@
  */
 package com.github.lukaszbudnik.dqueue;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -18,8 +20,10 @@ public interface QueueClient extends AutoCloseable {
 
     Future<UUID> publish(Item item);
 
-    Future<Optional<Item>> consume();
-
     Future<Optional<Item>> consume(Map<String, ?> filters);
+
+    default Future<Optional<Item>> consume() {
+        return consume(ImmutableMap.of());
+    }
 
 }

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientBuilder.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientBuilder.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientBuilder.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientBuilder.java
@@ -104,6 +104,11 @@ public class QueueClientBuilder {
         return queueClient;
     }
 
+    public SequentialQueueClient buildSequential() throws Exception {
+        SequentialQueueClientImpl queueClient = new SequentialQueueClientImpl(cassandraPort, cassandraAddress.split(","), cassandraKeyspace, cassandraTablePrefix, cassandraCreateTables, zookeeperClient, threadPoolSize, metricRegistry, healthCheckRegistry);
+        return queueClient;
+    }
+
     public int getCassandraPort() {
         return cassandraPort;
     }

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientImpl.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *
@@ -131,7 +131,7 @@ public class QueueClientImpl implements QueueClient {
         try {
             function.apply();
         } catch (Exception e) {
-            throw new RuntimeException();
+            throw new RuntimeException(e);
         } finally {
             timer.ifPresent(Timer.Context::stop);
         }

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientImpl.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientImpl.java
@@ -21,6 +21,8 @@ import com.datastax.driver.core.querybuilder.Select;
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -30,7 +32,6 @@ import java.nio.ByteBuffer;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
@@ -38,26 +39,27 @@ import java.util.concurrent.ThreadFactory;
 public class QueueClientImpl implements QueueClient {
 
     public static final String NO_FILTERS = "no_filters";
-    private final int cassandraPort;
-    private final String[] cassandraAddress;
-    private final String cassandraKeyspace;
-    private final String cassandraTablePrefix;
-    private final boolean cassandraCreateTables;
-    private final Cache<String, Boolean> cacheCreatedTables;
+
+    protected final int cassandraPort;
+    protected final String[] cassandraAddress;
+    protected final String cassandraKeyspace;
+    protected final String cassandraTablePrefix;
+    protected final boolean cassandraCreateTables;
+    protected final Cache<String, Boolean> cacheCreatedTables;
 
     // cassandra
-    private final Cluster cluster;
-    private final Session session;
+    protected final Cluster cluster;
+    protected final Session session;
 
     // zookeeper
-    private final CuratorFramework zookeeperClient;
+    protected final CuratorFramework zookeeperClient;
 
     // codahale
-    private final MetricRegistry metricRegistry;
-    private final HealthCheckRegistry healthCheckRegistry;
+    protected final MetricRegistry metricRegistry;
+    protected final HealthCheckRegistry healthCheckRegistry;
 
-    private final ThreadFactory threadFactory;
-    private final ExecutorService executorService;
+    protected final ThreadFactory threadFactory;
+    protected final ListeningExecutorService executorService;
 
     QueueClientImpl(int cassandraPort, String[] cassandraAddress, String cassandraKeyspace, String cassandraTablePrefix, boolean cassandraCreateTables, CuratorFramework zookeeperClient, int threadPoolSize, MetricRegistry metricRegistry, HealthCheckRegistry healthCheckRegistry) throws Exception {
         this.cassandraPort = cassandraPort;
@@ -106,14 +108,14 @@ public class QueueClientImpl implements QueueClient {
 
         threadFactory = new ThreadFactoryBuilder().setNameFormat("dqueue-thread-%d").build();
 
-        executorService = Executors.newFixedThreadPool(threadPoolSize, threadFactory);
+        executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(threadPoolSize, threadFactory));
     }
 
     Session getSession() {
         return session;
     }
 
-    private <R> R executeAndMeasureTime(NoArgFunction<R> function, String metricName) {
+    protected <R> R executeAndMeasureTime(NoArgFunction<R> function, String metricName) {
         Optional<Timer.Context> timer = Optional.ofNullable(metricRegistry).map(m -> m.timer(metricName).time());
         try {
             return function.apply();
@@ -124,7 +126,7 @@ public class QueueClientImpl implements QueueClient {
         }
     }
 
-    private void executeAndMeasureTime(NoArgVoidFunction function, String metricName) {
+    protected void executeAndMeasureTime(NoArgVoidFunction function, String metricName) {
         Optional<Timer.Context> timer = Optional.ofNullable(metricRegistry).map(m -> m.timer(metricName).time());
         try {
             function.apply();

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientImpl.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientImpl.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/QueueClientImpl.java
@@ -189,11 +189,6 @@ public class QueueClientImpl implements QueueClient {
     }
 
     @Override
-    public Future<Optional<Item>> consume() {
-        return consume(Collections.emptyMap());
-    }
-
-    @Override
     public Future<Optional<Item>> consume(Map<String, ?> filters) {
         if (filters == null) {
             throw new IllegalArgumentException("Filters cannot be null, if no filters are to be used pass an empty map");

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialItem.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialItem.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialItem.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialItem.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.dqueue;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.UUID;
+
+public class SequentialItem extends Item {
+    private final UUID dependency;
+
+    public SequentialItem(UUID startTime, UUID dependency, ByteBuffer contents) {
+        this(startTime, dependency, contents, ImmutableMap.of());
+    }
+
+    public SequentialItem(UUID startTime, UUID dependency, ByteBuffer contents, Map<String, ?> filters) {
+        super(startTime, contents, filters);
+        this.dependency = dependency;
+    }
+
+    public UUID getDependency() {
+        return dependency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SequentialItem that = (SequentialItem) o;
+
+        if (!dependency.equals(that.dependency)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + dependency.hashCode();
+        return result;
+    }
+}

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClient.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClient.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.dqueue;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Future;
+
+public interface SequentialQueueClient extends AutoCloseable {
+    Future<ImmutableList<UUID>> publishSequential(Item... items);
+
+    Future<Optional<SequentialItem>> consumeSequential();
+
+    Future<Optional<SequentialItem>> consumeSequential(Map<String, String> filters);
+
+    void delete(SequentialItem item);
+}

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClient.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClient.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClient.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClient.java
@@ -10,18 +10,28 @@
 package com.github.lukaszbudnik.dqueue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Future;
 
 public interface SequentialQueueClient extends AutoCloseable {
-    Future<ImmutableList<UUID>> publishSequential(Item... items);
 
-    Future<Optional<SequentialItem>> consumeSequential();
+    Future<ImmutableList<UUID>> publishSequential(List<Item> items);
+
+    default Future<ImmutableList<UUID>> publishSequential(Item... items) {
+        return publishSequential(Arrays.asList(items));
+    }
 
     Future<Optional<SequentialItem>> consumeSequential(Map<String, String> filters);
+
+    default Future<Optional<SequentialItem>> consumeSequential() {
+        return consumeSequential(ImmutableMap.of());
+    }
 
     void delete(SequentialItem item);
 }

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientImpl.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientImpl.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientImpl.java
+++ b/dqueue/src/main/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientImpl.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.dqueue;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.datastax.driver.core.*;
+import com.datastax.driver.core.querybuilder.Delete;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.querybuilder.Select;
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+
+import java.nio.ByteBuffer;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.Future;
+
+public class SequentialQueueClientImpl extends QueueClientImpl implements SequentialQueueClient {
+
+    private static final UUID zeroUUID = UUID.fromString("563dde00-219a-11b2-8080-808080808080");
+    private static final int QUEUED = 0;
+    private static final int FETCHED = 1;
+
+    SequentialQueueClientImpl(int cassandraPort, String[] cassandraAddress, String cassandraKeyspace, String cassandraTablePrefix, boolean cassandraCreateTables, CuratorFramework zookeeperClient, int threadPoolSize, MetricRegistry metricRegistry, HealthCheckRegistry healthCheckRegistry) throws Exception {
+        super(cassandraPort, cassandraAddress, cassandraKeyspace, cassandraTablePrefix, cassandraCreateTables, zookeeperClient, threadPoolSize, metricRegistry, healthCheckRegistry);
+    }
+
+    @Override
+    public Future<ImmutableList<UUID>> publishSequential(Item... items) {
+
+        Future<ImmutableList<UUID>> publishResult = executorService.submit(() -> {
+            UUID dependency = zeroUUID;
+            ImmutableList.Builder<UUID> uuids = ImmutableList.builder();
+
+            for (int i = 0; i < items.length; i++) {
+                Item item = items[i];
+                String filterNames;
+                if (item.getFilters().isEmpty()) {
+                    filterNames = NO_FILTERS;
+                } else {
+                    filterNames = String.join("_", item.getFilters().keySet());
+                }
+                String wholeOperationMetricName = "dqueue.publish." + filterNames + ".whole.timer";
+                Optional<Timer.Context> publishTimer = Optional.ofNullable(metricRegistry).map(m -> m.timer(wholeOperationMetricName).time());
+
+                try {
+                    String tableName = createSequentialTableIfNotExists("publish", filterNames, item.getFilters());
+
+                    Insert insert = buildInsert(dependency, item, QUEUED, tableName + "_queued");
+
+                    String cassandraInsertMetricName = "dqueue.publish." + filterNames + ".cassandraInsertQueued.timer";
+                    executeAndMeasureTime(() -> session.executeAsync(insert).getUninterruptibly(), cassandraInsertMetricName);
+
+                    dependency = item.getStartTime();
+
+                    uuids.add(dependency);
+                } finally {
+                    publishTimer.ifPresent(Timer.Context::stop);
+                }
+            }
+
+            return uuids.build();
+        });
+
+        return publishResult;
+    }
+
+    @Override
+    public void delete(SequentialItem item) {
+        String filterNames;
+        if (item.getFilters().isEmpty()) {
+            filterNames = NO_FILTERS;
+        } else {
+            filterNames = String.join("_", item.getFilters().keySet());
+        }
+        String tableName = createSequentialTableIfNotExists("delete", filterNames, item.getFilters());
+        Delete.Where delete = buildSequentialDelete(tableName + "_processing", item.getStartTime(), item.getFilters());
+        String cassandraDeleteOperationMetricName = "dqueue.consume." + filterNames + ".cassandraDelete.timer";
+        executeAndMeasureTime(() -> session.executeAsync(delete).getUninterruptibly(), cassandraDeleteOperationMetricName);
+    }
+
+    private Insert buildInsert(UUID dependency, Item item, int status, String tableName) {
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        String primaryKey = df.format(new Date(UUIDs.unixTimestamp(item.getStartTime())));
+
+        QueryBuilder queryBuilder = new QueryBuilder(cluster);
+
+        Insert insert = queryBuilder.insertInto(cassandraKeyspace, tableName)
+                .value("key", primaryKey)
+                .value("start_time", item.getStartTime())
+                .value("contents", item.getContents());
+
+        if (status == QUEUED) {
+            insert.value("dependency", dependency);
+        }
+
+        if (item.getFilters() != null && !item.getFilters().isEmpty()) {
+            for (String key : item.getFilters().keySet()) {
+                insert.value(key, item.getFilters().get(key));
+            }
+        }
+
+        return insert;
+    }
+
+    @Override
+    public Future<Optional<SequentialItem>> consumeSequential() {
+        return consumeSequential(ImmutableMap.of());
+    }
+
+    @Override
+    public Future<Optional<SequentialItem>> consumeSequential(Map<String, String> filters) {
+        Future<Optional<SequentialItem>> itemFuture = executorService.submit(() -> {
+
+            String filterNames;
+            if (filters.isEmpty()) {
+                filterNames = NO_FILTERS;
+            } else {
+                filterNames = String.join("_", filters.keySet());
+            }
+
+            String wholeOperationMetricName = "dqueue.consume." + filterNames + ".whole.timer";
+
+            Optional<Timer.Context> consumeTimer = Optional.ofNullable(metricRegistry).map(m -> m.timer(wholeOperationMetricName).time());
+
+            InterProcessMutex interProcessMutex = new InterProcessMutex(zookeeperClient, "/dqueue/" + filterNames);
+
+            try {
+                String mutexAcquireOperationMetricName = "dqueue.consume." + filterNames + ".mutextAcquire.timer";
+                executeAndMeasureTime(() -> interProcessMutex.acquire(), mutexAcquireOperationMetricName);
+
+                String tableName = createSequentialTableIfNotExists("consume", filterNames, filters);
+
+                Select.Where select = buildSequentialSelect(tableName + "_queued", filters);
+                String cassandraSelectOperationMetricName = "dqueue.consume." + filterNames + ".cassandraSelect.timer";
+                ResultSet resultSet = executeAndMeasureTime(() -> session.executeAsync(select).getUninterruptibly(), cassandraSelectOperationMetricName);
+                List<Row> rows = resultSet.all();
+
+                for (int i = 0; i < rows.size(); i++) {
+                    Row row = rows.get(i);
+
+                    UUID dependency = row.getUUID("dependency");
+
+                    if (!dependency.equals(zeroUUID)) {
+                        // check if dependency exists in processing
+                        Select dependencySelectInProcessing = buildDependencySelectInProcessing(tableName, dependency, filters);
+                        String cassandraDependencySelectProcessingOperationMetricName = "dqueue.consume." + filterNames + ".cassandraDependencySelectProcessing.timer";
+                        ResultSet dependencyResultSet = executeAndMeasureTime(() -> session.executeAsync(dependencySelectInProcessing).getUninterruptibly(), cassandraDependencySelectProcessingOperationMetricName);
+                        if (dependencyResultSet.one() != null) {
+                            break;
+                        }
+                        // check if dependency exists in queued
+                        Select dependencySelectInQueued = buildDependencySelectInQueued(tableName, dependency, filters);
+                        String cassandraDependencySelectQueuedOperationMetricName = "dqueue.consume." + filterNames + ".cassandraDependencySelectQueued.timer";
+                        dependencyResultSet = executeAndMeasureTime(() -> session.executeAsync(dependencySelectInQueued).getUninterruptibly(), cassandraDependencySelectQueuedOperationMetricName);
+                        if (dependencyResultSet.one() != null) {
+                            break;
+                        }
+                    }
+
+                    UUID startTime = row.getUUID("start_time");
+                    ByteBuffer contents = row.getBytes("contents");
+
+                    Delete.Where delete = buildSequentialDelete(tableName + "_queued", startTime, filters);
+                    String cassandraDeleteOperationMetricName = "dqueue.consume." + filterNames + ".cassandraDeleteQueued.timer";
+                    executeAndMeasureTime(() -> session.executeAsync(delete).getUninterruptibly(), cassandraDeleteOperationMetricName);
+
+                    Insert insertFetched = buildInsert(dependency, new Item(startTime, contents, filters), FETCHED, tableName + "_processing");
+
+                    String cassandraInsertMetricName = "dqueue.publish." + filterNames + ".cassandraInsertFetched.timer";
+                    executeAndMeasureTime(() -> session.executeAsync(insertFetched).getUninterruptibly(), cassandraInsertMetricName);
+
+                    return Optional.of(new SequentialItem(startTime, dependency, contents, filters));
+                }
+
+                return Optional.empty();
+
+            } finally {
+                interProcessMutex.release();
+                consumeTimer.ifPresent(Timer.Context::stop);
+            }
+        });
+
+        return itemFuture;
+    }
+
+    private Delete.Where buildSequentialDelete(String tableName, UUID startTime, Map<String, ?> filters) {
+        long timestamp = UUIDs.unixTimestamp(startTime);
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        String key = df.format(new Date(timestamp));
+
+        QueryBuilder queryBuilder = new QueryBuilder(session.getCluster());
+        Delete.Where delete = queryBuilder.delete().from(cassandraKeyspace, tableName)
+                .where(QueryBuilder.eq("key", key))
+                .and(QueryBuilder.eq("start_time", startTime));
+
+        if (filters != null && !filters.isEmpty()) {
+            for (String filter : filters.keySet()) {
+                delete.and(QueryBuilder.eq(filter, filters.get(filter)));
+            }
+        }
+
+        return delete;
+    }
+
+    private Select.Where buildSequentialSelectWithoutStatus(String tableName, Map<String, String> filters) {
+        long nowTimestamp = System.currentTimeMillis();
+        long yesterdayTimestamp = nowTimestamp - 24 * 60 * 60 * 1_000;
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        String nowKey = df.format(new Date(nowTimestamp));
+        String yesterdayKey = df.format(new Date(yesterdayTimestamp));
+
+        QueryBuilder queryBuilder = new QueryBuilder(session.getCluster());
+        Select.Where select = queryBuilder.select().all()
+                .from(cassandraKeyspace, tableName)
+                .where(QueryBuilder.in("key", nowKey, yesterdayKey));
+
+        if (filters != null && filters.size() > 0) {
+            for (String filter : filters.keySet()) {
+                select.and(QueryBuilder.eq(filter, filters.get(filter)));
+            }
+        }
+
+        return select;
+    }
+
+    private Select.Where buildSequentialSelect(String tableName, Map<String, String> filters) {
+        Select.Where select = buildSequentialSelectWithoutStatus(tableName, filters);
+        select.and(QueryBuilder.lt("start_time", UUIDs.endOf(System.currentTimeMillis())));
+
+        return select;
+    }
+
+    private Select buildDependencySelectInProcessing(String tableName, UUID dependency, Map<String, String> filters) {
+        Select.Where select = buildSequentialSelectWithoutStatus(tableName + "_processing", filters);
+
+        select.and(QueryBuilder.eq("start_time", dependency));
+
+        return select.limit(1);
+    }
+
+    private Select buildDependencySelectInQueued(String tableName, UUID dependency, Map<String, String> filters) {
+        Select.Where select = buildSequentialSelectWithoutStatus(tableName + "_queued", filters);
+
+        select.and(QueryBuilder.eq("start_time", dependency));
+
+        return select.limit(1);
+    }
+
+    private String createSequentialTableIfNotExists(String operation, String filterNames, Map<String, ?> filters) {
+        String tableName = cassandraTablePrefix + "_" + filterNames;
+        if (cassandraCreateTables && cacheCreatedTables.getIfPresent(filterNames) == null) {
+            String columns = ", ";
+            String columnsAndTypes = "";
+            if (!filters.isEmpty()) {
+                columns += String.join(", ", filters.keySet()) + ", ";
+                for (String filter : filters.keySet()) {
+                    TypeCodec typeCodec = CodecRegistry.DEFAULT_INSTANCE.codecFor(filters.get(filter));
+                    DataType.Name cqlType = typeCodec.getCqlType().getName();
+                    columnsAndTypes += filter + " " + cqlType.name() + ", ";
+                }
+
+            }
+            String createTableQueued = "create table if not exists " + cassandraKeyspace + "." + tableName + "_queued ( key varchar, " + columnsAndTypes + " contents blob, start_time timeuuid, dependency timeuuid, primary key (key " + columns + " start_time, dependency) ) ";
+            String createTableProcessing = "create table if not exists " + cassandraKeyspace + "." + tableName + "_processing ( key varchar, " + columnsAndTypes + " contents blob, start_time timeuuid, primary key (key " + columns + " start_time) ) ";
+
+            String createTableMetricName = "dqueue." + operation + "." + filterNames + ".cassandraCreateTable.timer";
+            executeAndMeasureTime(() -> {
+                session.execute(createTableQueued).one();
+                session.execute(createTableProcessing).one();
+            }, createTableMetricName);
+            cacheCreatedTables.put(filterNames, Boolean.TRUE);
+        }
+        return tableName;
+    }
+
+}

--- a/dqueue/src/test/java/com/datastax/driver/core/utils/UUIDsTesting.java
+++ b/dqueue/src/test/java/com/datastax/driver/core/utils/UUIDsTesting.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/test/java/com/datastax/driver/core/utils/UUIDsTesting.java
+++ b/dqueue/src/test/java/com/datastax/driver/core/utils/UUIDsTesting.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/QueueClientIntegrationTest.java
+++ b/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/QueueClientIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/QueueClientIntegrationTest.java
+++ b/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/QueueClientIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/QueueClientPerformanceTest.java
+++ b/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/QueueClientPerformanceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/QueueClientPerformanceTest.java
+++ b/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/QueueClientPerformanceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *
@@ -168,14 +168,14 @@ public class QueueClientPerformanceTest {
             UUID startTime = UUIDs.timeBased();
             Future<UUID> id = queueClient.publish(new Item(startTime, buffer, filters));
             try {
-                id.get();
+                Assert.assertEquals(startTime, id.get());
             } catch (Exception e) {
                 fail(e.getMessage());
             }
         });
 
         IntStream.range(0, NUMBER_OF_ITERATIONS).forEach((i) -> {
-            Future<Optional<Item>> itemFuture = queueClient.consume();
+            Future<Optional<Item>> itemFuture = queueClient.consume(filters);
 
             Optional<Item> item = null;
             try {

--- a/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientIntegrationTest.java
+++ b/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+ * Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
  *

--- a/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientIntegrationTest.java
+++ b/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientIntegrationTest.java
@@ -124,35 +124,35 @@ public class SequentialQueueClientIntegrationTest {
         );
         futures.get();
 
-        Future<Optional<SequentialItem>> optionalFutureA = queueClient.consumeSequential(ImmutableMap.of());
+        Future<Optional<SequentialItem>> optionalFutureA = queueClient.consumeSequential();
         Optional<SequentialItem> itemOptionalA = optionalFutureA.get();
         SequentialItem itemA = itemOptionalA.get();
 
         assertNotNull(itemA);
         assertEquals("A", new String(itemA.getContents().array()));
 
-        Future<Optional<SequentialItem>> optionalFutureB = queueClient.consumeSequential(ImmutableMap.of());
+        Future<Optional<SequentialItem>> optionalFutureB = queueClient.consumeSequential();
         Optional<SequentialItem> itemOptionalB = optionalFutureB.get();
 
         assertFalse(itemOptionalB.isPresent());
 
         queueClient.delete(itemA);
 
-        optionalFutureB = queueClient.consumeSequential(ImmutableMap.of());
+        optionalFutureB = queueClient.consumeSequential();
         itemOptionalB = optionalFutureB.get();
         SequentialItem itemB = itemOptionalB.get();
 
         assertNotNull(itemB);
         assertEquals("B", new String(itemB.getContents().array()));
 
-        Future<Optional<SequentialItem>> optionalFutureC = queueClient.consumeSequential(ImmutableMap.of());
+        Future<Optional<SequentialItem>> optionalFutureC = queueClient.consumeSequential();
         Optional<SequentialItem> itemOptionalC = optionalFutureC.get();
 
         assertFalse(itemOptionalC.isPresent());
 
         queueClient.delete(itemB);
 
-        optionalFutureC = queueClient.consumeSequential(ImmutableMap.of());
+        optionalFutureC = queueClient.consumeSequential();
         itemOptionalC = optionalFutureC.get();
         SequentialItem itemC = itemOptionalC.get();
 
@@ -161,7 +161,7 @@ public class SequentialQueueClientIntegrationTest {
 
         queueClient.delete(itemC);
 
-        Future<Optional<SequentialItem>> empty = queueClient.consumeSequential(ImmutableMap.of());
+        Future<Optional<SequentialItem>> empty = queueClient.consumeSequential();
         assertFalse(empty.get().isPresent());
     }
 

--- a/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientIntegrationTest.java
+++ b/dqueue/src/test/java/com/github/lukaszbudnik/dqueue/SequentialQueueClientIntegrationTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.dqueue;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.utils.UUIDs;
+import com.github.lukaszbudnik.cloudtag.CloudTagEnsembleProvider;
+import com.github.lukaszbudnik.gpe.PropertiesElResolverModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.commons.io.IOUtils;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.junit.*;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class SequentialQueueClientIntegrationTest {
+
+    private static Injector injector;
+    private static CuratorFramework zookeeperClient;
+
+    private static String cassandraKeyspace = "test" + System.currentTimeMillis();
+    private SequentialQueueClientImpl queueClient;
+    private Session session;
+    private MetricRegistry metricRegistry;
+    private HealthCheckRegistry healthCheckRegistry;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        injector = Guice.createInjector(new PropertiesElResolverModule(Arrays.asList("/dqueue.properties", "/cloudtag.properties")));
+
+        CloudTagEnsembleProvider cloudTagEnsembleProvider = injector.getInstance(CloudTagEnsembleProvider.class);
+        RetryPolicy retryPolicy = new ExponentialBackoffRetry(1000, 3);
+        zookeeperClient = CuratorFrameworkFactory.builder().ensembleProvider(cloudTagEnsembleProvider).retryPolicy(retryPolicy).build();
+        zookeeperClient.start();
+        // warm up zookeeper zookeeperClient - on my macbook pro takes even up to 10 seconds
+        zookeeperClient.getChildren().forPath("/");
+    }
+
+    @Before
+    public void before() throws Exception {
+        QueueClientBuilder queueClientBuilder = injector.getInstance(QueueClientBuilder.class);
+
+        metricRegistry = new MetricRegistry();
+        healthCheckRegistry = new HealthCheckRegistry();
+
+        queueClient = (SequentialQueueClientImpl) queueClientBuilder
+                .withCassandraKeyspace(cassandraKeyspace)
+                .withZookeeperClient(zookeeperClient)
+                .withMetricRegistry(metricRegistry)
+                .withHealthMetricRegistry(healthCheckRegistry)
+                .buildSequential();
+
+        session = queueClient.getSession();
+        session.execute("create keyspace " + cassandraKeyspace + " WITH replication = {'class':'SimpleStrategy', 'replication_factor':3}");
+    }
+
+    @After
+    public void after() throws Exception {
+        session.execute("drop keyspace " + cassandraKeyspace);
+
+        SortedMap<String, Timer> timers = metricRegistry.getTimers();
+
+        timers.keySet().stream().forEach(k -> {
+            Timer t = timers.get(k);
+            System.out.println(k);
+            System.out.println("\ttimes called ==> " + t.getCount());
+            System.out.println("\tmedian ==> " + t.getSnapshot().getMedian() / 1000 / 1000);
+            System.out.println("\t75th percentile ==> " + t.getSnapshot().get75thPercentile() / 1000 / 1000);
+            System.out.println("\t99th percentile ==> " + t.getSnapshot().get99thPercentile() / 1000 / 1000);
+        });
+
+        SortedMap<String, HealthCheck.Result> healthChecks = healthCheckRegistry.runHealthChecks();
+        healthChecks.keySet().stream().forEach(k -> {
+            HealthCheck.Result healthCheck = healthChecks.get(k);
+            System.out.println(k + " healthy? ==> " + healthCheck.isHealthy());
+        });
+
+        queueClient.close();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        IOUtils.closeQuietly(zookeeperClient);
+    }
+
+    @Test
+    public void shouldPublishSequential() throws ExecutionException, InterruptedException {
+        Future<ImmutableList<UUID>> futures = queueClient.publishSequential(
+                new Item(UUIDs.timeBased(), ByteBuffer.wrap("A".getBytes())),
+                new Item(UUIDs.timeBased(), ByteBuffer.wrap("B".getBytes())),
+                new Item(UUIDs.timeBased(), ByteBuffer.wrap("C".getBytes()))
+        );
+        futures.get();
+
+        Future<Optional<SequentialItem>> optionalFutureA = queueClient.consumeSequential(ImmutableMap.of());
+        Optional<SequentialItem> itemOptionalA = optionalFutureA.get();
+        SequentialItem itemA = itemOptionalA.get();
+
+        assertNotNull(itemA);
+        assertEquals("A", new String(itemA.getContents().array()));
+
+        Future<Optional<SequentialItem>> optionalFutureB = queueClient.consumeSequential(ImmutableMap.of());
+        Optional<SequentialItem> itemOptionalB = optionalFutureB.get();
+
+        assertFalse(itemOptionalB.isPresent());
+
+        queueClient.delete(itemA);
+
+        optionalFutureB = queueClient.consumeSequential(ImmutableMap.of());
+        itemOptionalB = optionalFutureB.get();
+        SequentialItem itemB = itemOptionalB.get();
+
+        assertNotNull(itemB);
+        assertEquals("B", new String(itemB.getContents().array()));
+
+        Future<Optional<SequentialItem>> optionalFutureC = queueClient.consumeSequential(ImmutableMap.of());
+        Optional<SequentialItem> itemOptionalC = optionalFutureC.get();
+
+        assertFalse(itemOptionalC.isPresent());
+
+        queueClient.delete(itemB);
+
+        optionalFutureC = queueClient.consumeSequential(ImmutableMap.of());
+        itemOptionalC = optionalFutureC.get();
+        SequentialItem itemC = itemOptionalC.get();
+
+        assertNotNull(itemC);
+        assertEquals("C", new String(itemC.getContents().array()));
+
+        queueClient.delete(itemC);
+
+        Future<Optional<SequentialItem>> empty = queueClient.consumeSequential(ImmutableMap.of());
+        assertFalse(empty.get().isPresent());
+    }
+
+}

--- a/dqueue/src/test/resources/cloudtag.properties
+++ b/dqueue/src/test/resources/cloudtag.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+# Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 #

--- a/dqueue/src/test/resources/cloudtag.properties
+++ b/dqueue/src/test/resources/cloudtag.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+# Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 #

--- a/dqueue/src/test/resources/dqueue.properties
+++ b/dqueue/src/test/resources/dqueue.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+# Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 #

--- a/dqueue/src/test/resources/dqueue.properties
+++ b/dqueue/src/test/resources/dqueue.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 Łukasz Budnik <lukasz.budnik@gmail.com>
+# Copyright (C) 2015-2016 Łukasz Budnik <lukasz.budnik@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 #


### PR DESCRIPTION
There is now an option to submit sequenced items, just like this:

```
Map<String, String> filters = ImmutableMap.of("filter1", "1", "filter2", "two");
Future<ImmutableList<UUID>> futures = queueClient.publishSequential(
        new Item(UUIDs.timeBased(), ByteBuffer.wrap("A".getBytes()), filters),
        new Item(UUIDs.timeBased(), ByteBuffer.wrap("B".getBytes()), filters),
        new Item(UUIDs.timeBased(), ByteBuffer.wrap("C".getBytes()), filters)
);
```

Item B won't be fetched until item A won't be removed from queue. Item C won't be fetched until item B won't be removed from queue.

Yes, the `SequentialQueueClient` has a new method called `void delete(SequentialItem item);` which needs to be explicitly called in order to remove item from the queue. Not removing items from the queue will block all other items in its sequence.
